### PR TITLE
Fix uniform grid violation of POLA

### DIFF
--- a/src/gemini3d/grid/uniform.py
+++ b/src/gemini3d/grid/uniform.py
@@ -40,7 +40,7 @@ def uniform1d(xmin: float, xmax: float, L: int):
         x = np.linspace(xmin, xmax, L + 4)
     else:
         # exclude the ghost cells when setting extents
-        x = np.linspace(xmin, xmax, L)
+        x = np.linspace(xmin, xmax, L, endpoint=False)
         d0 = x[1] - x[0]
         d1 = x[-1] - x[-2]
         # now tack on ghost cells so they are outside user-specified region


### PR DESCRIPTION
Due to how [numpy.linspace](https://numpy.org/doc/stable/reference/generated/numpy.linspace.html) handles endpoints, the grid setup script was violating the [Principle of Least Astonishment (POLA)](https://en.wikipedia.org/wiki/Principle_of_least_astonishment).  When the length of the grid dimension is set to 128 km and the number of grid cells to 128, the resulting grid cells have a dimension of 1007 m rather than 1000 m.  This has been fixed.

Note that I have not adjusted [Line 40](https://github.com/ljlamarche/pygemini/blob/56c0f9b4259c4dd264fbb8d2a7e1350d14adb2e0/src/gemini3d/grid/uniform.py#L40) which deals with the degenerate dimension case.